### PR TITLE
Break circular dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,6 +25,7 @@
         <commons-compress.version>1.7</commons-compress.version>
         <open-csv.version>2.3</open-csv.version>
         <super-csv.version>2.1.0</super-csv.version>
+        <sb11-shared-code.version>0.0.6-SNAPSHOT</sb11-shared-code.version>
         <sb11-shared-security.version>0.0.1-SNAPSHOT</sb11-shared-security.version>
         <tds-dll.version>0.0.1-SNAPSHOT</tds-dll.version>
     </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
     <parent>
         <groupId>org.opentestsystem.shared</groupId>
         <artifactId>shared-build-parent</artifactId>
-        <version>0.0.7-SNAPSHOT</version>
+        <version>3.0.0</version>
     </parent>
 
     <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -24,6 +24,7 @@
         <bouncycastle.version>1.50</bouncycastle.version>
         <commons-compress.version>1.7</commons-compress.version>
         <open-csv.version>2.3</open-csv.version>
+        <rest-api-generator.version>0.0.3-SNAPSHOT</rest-api-generator.version>
         <super-csv.version>2.1.0</super-csv.version>
         <sb11-shared-code.version>0.0.6-SNAPSHOT</sb11-shared-code.version>
         <sb11-shared-security.version>0.0.1-SNAPSHOT</sb11-shared-security.version>

--- a/pom.xml
+++ b/pom.xml
@@ -24,6 +24,7 @@
         <bouncycastle.version>1.50</bouncycastle.version>
         <commons-compress.version>1.7</commons-compress.version>
         <open-csv.version>2.3</open-csv.version>
+        <progman-client.version>0.0.4-SNAPSHOT</progman-client.version>
         <rest-api-generator.version>0.0.3-SNAPSHOT</rest-api-generator.version>
         <super-csv.version>2.1.0</super-csv.version>
         <sb11-shared-code.version>0.0.6-SNAPSHOT</sb11-shared-code.version>

--- a/pom.xml
+++ b/pom.xml
@@ -31,6 +31,7 @@
         <sb11-shared-code.version>0.0.6-SNAPSHOT</sb11-shared-code.version>
         <sb11-shared-security.version>0.0.1-SNAPSHOT</sb11-shared-security.version>
         <tds-dll.version>0.0.1-SNAPSHOT</tds-dll.version>
+        <tsb-client.version>0.0.1-SNAPSHOT</tsb-client.version>
     </properties>
 
     <scm>

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
     <parent>
         <groupId>org.opentestsystem.shared</groupId>
         <artifactId>shared-build-parent</artifactId>
-        <version>3.0.1</version>
+        <version>3.0.2</version>
     </parent>
 
     <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
     <parent>
         <groupId>org.opentestsystem.shared</groupId>
         <artifactId>shared-build-parent</artifactId>
-        <version>3.0.0</version>
+        <version>3.0.1</version>
     </parent>
 
     <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -27,6 +27,7 @@
         <progman-client.version>0.0.4-SNAPSHOT</progman-client.version>
         <rest-api-generator.version>0.0.3-SNAPSHOT</rest-api-generator.version>
         <super-csv.version>2.1.0</super-csv.version>
+        <sb11-mna-client.version>0.0.4-SNAPSHOT</sb11-mna-client.version>
         <sb11-shared-code.version>0.0.6-SNAPSHOT</sb11-shared-code.version>
         <sb11-shared-security.version>0.0.1-SNAPSHOT</sb11-shared-security.version>
         <tds-dll.version>0.0.1-SNAPSHOT</tds-dll.version>


### PR DESCRIPTION
Move inter-project versions from old parent POM version into this project.
Update parent POM to released version.