### PR TITLE
Cache incessantly called progman method to speed up student eligibility checking.

### DIFF
--- a/persistence/src/main/java/org/opentestsystem/delivery/testreg/eligibility/EligibilityEvaluatorImpl.java
+++ b/persistence/src/main/java/org/opentestsystem/delivery/testreg/eligibility/EligibilityEvaluatorImpl.java
@@ -7,13 +7,11 @@ http://www.smarterapp.org/documents/American_Institutes_for_Research_Open_Source
 
 package org.opentestsystem.delivery.testreg.eligibility;
 
-import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-
+import com.google.common.collect.Iterables;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+import com.google.common.collect.Multimaps;
+import com.google.common.collect.Sets;
 import org.apache.commons.beanutils.PropertyUtils;
 import org.joda.time.DateTime;
 import org.joda.time.format.DateTimeFormat;
@@ -49,18 +47,33 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.integration.annotation.ServiceActivator;
 import org.springframework.stereotype.Component;
 import org.springframework.util.CollectionUtils;
 
-import com.google.common.collect.Iterables;
-import com.google.common.collect.Lists;
-import com.google.common.collect.Maps;
-import com.google.common.collect.Multimaps;
-import com.google.common.collect.Sets;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
 
 @Component
 public class EligibilityEvaluatorImpl implements EligibilityEvaluator {
+
+    @Component
+    static class TenancyServiceCache {
+
+        @Autowired
+        private TenancyService tenancyService;
+
+        @Cacheable("applicableTenants")
+        public List<Tenant> getApplicableTenants(final Set<SbacEntity> possibleTenants) {
+            return tenancyService.getApplicableTenants(possibleTenants);
+        }
+    }
 
     private static final Logger LOGGER = LoggerFactory.getLogger(EligibilityEvaluatorImpl.class);
 
@@ -79,7 +92,7 @@ public class EligibilityEvaluatorImpl implements EligibilityEvaluator {
     private ExplicitEligibilityRepository explicitEligRepository;
 
     @Autowired
-    private TenancyService tenancyService;
+    private TenancyServiceCache tenancyServiceCache;
 
     @Autowired
     private ProgManClient progmanClient;
@@ -201,7 +214,7 @@ public class EligibilityEvaluatorImpl implements EligibilityEvaluator {
             // entity name is just hardcoded because the tenancy service just checks to see if it exists and doesn't use it for anything
             // this gets around having to make another db call to find the actual entity name
             if (!CollectionUtils.isEmpty(possibleTenants)) {
-                tenantsForAssessment = this.tenancyService.getApplicableTenants(possibleTenants);
+                tenantsForAssessment = tenancyServiceCache.getApplicableTenants(possibleTenants);
             }
 
             final List<String> tenantIdsForAssessment = Lists.newArrayList();

--- a/persistence/src/main/java/org/opentestsystem/delivery/testreg/persistence/config/TestRegCachingConfig.java
+++ b/persistence/src/main/java/org/opentestsystem/delivery/testreg/persistence/config/TestRegCachingConfig.java
@@ -27,18 +27,24 @@ public class TestRegCachingConfig {
         config.setName("testRegCacheManager");
         config.setUpdateCheck(false);
 
-        // TODO: We should probably configure each cache differently (assuming they need different configuration)
-        final String[] cacheNames = { "Testreg.Client", "SbacRolesAsSbacEntitiesAsMongoIds", "roleToEntityCache",
-                "institution.ncesid", "sb11EntityCache", "accessibleUsersCache", "accommodationCache"};
+        final String[] cacheNames = {"Testreg.Client", "SbacRolesAsSbacEntitiesAsMongoIds", "roleToEntityCache",
+            "institution.ncesid", "sb11EntityCache", "accessibleUsersCache", "accommodationCache"};
         for (final String cacheName : cacheNames) {
             final Cache c = new Cache(new CacheConfiguration(cacheName, 1000).memoryStoreEvictionPolicy("LRU"));
             config.addCache(c.getCacheConfiguration());
         }
 
         final Cache c = new Cache(
-                new CacheConfiguration("UberEntityRelationshipMap", 10000)
-                        .memoryStoreEvictionPolicy(MemoryStoreEvictionPolicy.LRU));
+            new CacheConfiguration("UberEntityRelationshipMap", 10000)
+                .memoryStoreEvictionPolicy(MemoryStoreEvictionPolicy.LRU));
         config.addCache(c.getCacheConfiguration());
+
+        // Only cache this progman data for one hour.
+        final Cache atc = new Cache(
+            new CacheConfiguration("applicableTenants", 10000)
+                .timeToLiveSeconds(1 * 60 * 60)
+                .memoryStoreEvictionPolicy(MemoryStoreEvictionPolicy.LRU));
+        config.addCache(atc.getCacheConfiguration());
 
         return net.sf.ehcache.CacheManager.newInstance(config);
     }


### PR DESCRIPTION
The student eligibility evaluator was hitting progman for every processed student. We want to import millions of students quickly, so this needs to be cached. 

Extracted the method being overused into a cache class, added @Cacheable to the method, and configured it to have a one hour TTL. From home, this seems to have doubled the throughput of the student eligibility processing (progman is remote - on aws the cache will likely have a lesser impact, but progman will be happier).
