### PR TITLE
Cache over calculated tenant-by-inst/state info and clean ad-hoc cache map.

### DIFF
--- a/persistence/src/main/java/org/opentestsystem/delivery/testreg/eligibility/EligibilityEvaluatorImpl.java
+++ b/persistence/src/main/java/org/opentestsystem/delivery/testreg/eligibility/EligibilityEvaluatorImpl.java
@@ -9,8 +9,6 @@ package org.opentestsystem.delivery.testreg.eligibility;
 
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
-import com.google.common.collect.Maps;
-import com.google.common.collect.Multimaps;
 import com.google.common.collect.Sets;
 import org.apache.commons.beanutils.PropertyUtils;
 import org.joda.time.DateTime;
@@ -64,14 +62,85 @@ import java.util.Set;
 public class EligibilityEvaluatorImpl implements EligibilityEvaluator {
 
     @Component
-    static class TenancyServiceCache {
+    static class EligibilityEvaluatorCache {
+
+        @Autowired
+        private ProgManClient progmanClient;
 
         @Autowired
         private TenancyService tenancyService;
 
+        @Cacheable("tenantById")
+        public Tenant getTenantById(String tenantId) {
+            return this.progmanClient.getTenantById(tenantId);
+        }
+
         @Cacheable("applicableTenants")
-        public List<Tenant> getApplicableTenants(final Set<SbacEntity> possibleTenants) {
-            return tenancyService.getApplicableTenants(possibleTenants);
+        public List<String> getApplicableTenantIds(final Set<SbacEntity> possibleTenants) {
+            List<Tenant> tenantsForAssessment = Lists.newArrayList();
+            if (!CollectionUtils.isEmpty(possibleTenants)) {
+                tenantsForAssessment = tenancyService.getApplicableTenants(possibleTenants);
+            }
+            final List<String> tenantIdsForAssessment = Lists.newArrayList();
+            if (!CollectionUtils.isEmpty(tenantsForAssessment)) {
+                tenantIdsForAssessment.addAll(Lists.transform(tenantsForAssessment, ARTHelpers.TENANT_ID_TRANSFORMER));
+            }
+            return tenantIdsForAssessment;
+        }
+
+        @Cacheable("implicitAssessments")
+        public List<Assessment> getImplicitAssessments(String institutionIdentifier, String stateAbbreviation, Sb11EntityRepositoryService sb11EntityService, AssessmentRepository assessmentRepository) {
+            // go up the hierarchy to find all the entities up to the client and add to the hash set
+            // we need to know if any of the levels are tenants so we grab all possible assessments for the hierarchy
+            Sb11Entity entity = sb11EntityService.findByEntityIdAndStateAbbreviation(institutionIdentifier, stateAbbreviation, InstitutionEntity.class);
+
+            // create the initial set with the institution level
+            final Set<SbacEntity> possibleTenants = Sets.newHashSet(new SbacEntity(TenantType.INSTITUTION, institutionIdentifier, "nothing"));
+
+            while (entity != null) {
+                if (entity.getParentEntityType() != null) {
+                    final TenantType tenantType = convertHierarchyLevelToTenantType(entity.getParentEntityType());
+                    if (tenantType != null) {
+                        possibleTenants.add(new SbacEntity(tenantType, entity.getParentEntityId(), "nothing"));
+                    }
+                }
+                entity = entity.getParentEntityId() != null ? sb11EntityService.getParentEntity(entity) : null;
+            }
+
+            // find all assessments for possible tenants
+            final List<String> tenantIdsForAssessment = getApplicableTenantIds(possibleTenants);
+            List<Assessment> implicitAssessments = Lists.newArrayList();
+            if (!CollectionUtils.isEmpty(tenantIdsForAssessment)) {
+                implicitAssessments = assessmentRepository.findByEligibilityTypeAndTenantIdIsIn("IMPLICIT", tenantIdsForAssessment);
+            }
+            return CollectionUtils.isEmpty(implicitAssessments) ? new ArrayList<Assessment>() : implicitAssessments;
+        }
+
+        private static TenantType convertHierarchyLevelToTenantType(final HierarchyLevel level) {
+            TenantType converted = null;
+
+            switch (level) {
+                case DISTRICT:
+                    converted = TenantType.DISTRICT;
+                    break;
+                case GROUPOFDISTRICTS:
+                    converted = TenantType.DISTRICT_GROUP;
+                    break;
+                case GROUPOFINSTITUTIONS:
+                    converted = TenantType.INSTITUTION_GROUP;
+                    break;
+                case GROUPOFSTATES:
+                    converted = TenantType.STATE_GROUP;
+                    break;
+                case STATE:
+                    converted = TenantType.STATE;
+                    break;
+                default:
+                    converted = null;
+                    break;
+            }
+
+            return converted;
         }
     }
 
@@ -92,10 +161,7 @@ public class EligibilityEvaluatorImpl implements EligibilityEvaluator {
     private ExplicitEligibilityRepository explicitEligRepository;
 
     @Autowired
-    private TenancyServiceCache tenancyServiceCache;
-
-    @Autowired
-    private ProgManClient progmanClient;
+    private EligibilityEvaluatorCache eligibilityEvaluatorCache;
 
     @Autowired
     private Sb11EntityRepositoryService sb11EntityService;
@@ -151,19 +217,18 @@ public class EligibilityEvaluatorImpl implements EligibilityEvaluator {
     public void evaluateStudentModification(final StudentModificationEvent event) {
 
         LOGGER.debug("Handling a StudentModificationEvent: " + event);
-        final Map<String, Map<String, List<Assessment>>> studentInstitutionTenantAssessmentMap = Maps.newHashMap();
         switch (event.getAction()) {
-        case UPD:
-            processImplicitEligibilityForStudent(event.getSource(), studentInstitutionTenantAssessmentMap);
-            processExplicitEligibilityForStudent(event.getSource());
-            break;
-        case DEL:
-            studentDeleted(event.getSource());
-            break;
-        default:
-            // unknown, throw error here
-            LOGGER.error("Unknown action: " + event.getAction());
-            throw new EligibilityException("eligibility.unknown.event");
+            case UPD:
+                processImplicitEligibilityForStudent(event.getSource());
+                processExplicitEligibilityForStudent(event.getSource());
+                break;
+            case DEL:
+                studentDeleted(event.getSource());
+                break;
+            default:
+                // unknown, throw error here
+                LOGGER.error("Unknown action: " + event.getAction());
+                throw new EligibilityException("eligibility.unknown.event");
         }
     }
 
@@ -173,72 +238,22 @@ public class EligibilityEvaluatorImpl implements EligibilityEvaluator {
         LOGGER.debug("Handling a BatchStudentModificationEvent: " + event);
         final List<Student> studentList = event.getSource();
 
-        final Map<String, Map<String, List<Assessment>>> studentInstitutionTenantAssessmentMap = Maps.newHashMap();
         for (final Student student : studentList) {
-            processImplicitEligibilityForStudent(student, studentInstitutionTenantAssessmentMap);
+            processImplicitEligibilityForStudent(student);
             processExplicitEligibilityForStudent(student);
         }
     }
 
-    private void processImplicitEligibilityForStudent(final Student student, final Map<String, Map<String, List<Assessment>>> studentInstitutionTenantAssessmentMap) {
+    private void processImplicitEligibilityForStudent(final Student student) {
         // if a student is inserted or modified, the student must be checked against all
         // implicit rules on all assessments marked as implicit
         // remove EligibleStudent for this student
         // find all EligibleAssessments with this student id and modify to remove student
         // find all Assessments that use IMPLICIT eligibility and run all rules against this student
-        
         this.eligibilityService.removeAllAssociationsForStudent(student);
 
-        // go up the hierarchy to find all the entities up to the client and add to the hash set
-        // we need to know if any of the levels are tenants so we grab all possible assessments for the hierarchy
-        List<Tenant> tenantsForAssessment = Lists.newArrayList();
-        final List<Assessment> implicitAssessments = Lists.newArrayList();
-        final Map<String, List<Assessment>> processedInstutitionEntityData = studentInstitutionTenantAssessmentMap.get(student.getInstitutionIdentifier());
-        if (processedInstutitionEntityData == null) {
-            Sb11Entity entity = this.sb11EntityService.findByEntityIdAndStateAbbreviation(student.getInstitutionIdentifier(), student.getStateAbbreviation(), InstitutionEntity.class);
-
-            // create the initial set with the institution level
-            final Set<SbacEntity> possibleTenants = Sets.newHashSet(new SbacEntity(TenantType.INSTITUTION, student.getInstitutionIdentifier(), "nothing"));
-
-            while (entity != null) {
-                if (entity.getParentEntityType() != null) {
-                    final TenantType tenantType = convertHierarchyLevelToTenantType(entity.getParentEntityType());
-                    if (tenantType != null) {
-                        possibleTenants.add(new SbacEntity(tenantType, entity.getParentEntityId(), "nothing"));
-                    }
-                }
-                entity = entity.getParentEntityId() != null ? this.sb11EntityService.getParentEntity(entity) : null;
-            }
-
-            // filter assessments returned by tenant. need to find tenant for the student
-            // entity name is just hardcoded because the tenancy service just checks to see if it exists and doesn't use it for anything
-            // this gets around having to make another db call to find the actual entity name
-            if (!CollectionUtils.isEmpty(possibleTenants)) {
-                tenantsForAssessment = tenancyServiceCache.getApplicableTenants(possibleTenants);
-            }
-
-            final List<String> tenantIdsForAssessment = Lists.newArrayList();
-
-            if (!CollectionUtils.isEmpty(tenantsForAssessment)) {
-                tenantIdsForAssessment.addAll(Lists.transform(tenantsForAssessment, ARTHelpers.TENANT_ID_TRANSFORMER));
-            }
-
-            if (!CollectionUtils.isEmpty(tenantIdsForAssessment)) {
-                final Map<String, List<Assessment>> tenantAssessmentMap = Maps.newHashMap();
-                final List<Assessment> additionalImplicitAssessments = this.assessmentRepository.findByEligibilityTypeAndTenantIdIsIn("IMPLICIT", tenantIdsForAssessment);
-                tenantAssessmentMap.putAll(Multimaps.asMap(Multimaps.index(additionalImplicitAssessments, ARTHelpers.ASSESSMENT_TENANTID_TRANSFORMER)));
-                studentInstitutionTenantAssessmentMap.put(student.getInstitutionIdentifier(), tenantAssessmentMap);
-                for (final String tenantId : tenantIdsForAssessment) {
-                    final List<Assessment> foundAssessments = tenantAssessmentMap.get(tenantId);
-                    if (!CollectionUtils.isEmpty(foundAssessments)) {
-                        implicitAssessments.addAll(tenantAssessmentMap.get(tenantId));
-                    }
-                }
-            }
-        } else {
-            implicitAssessments.addAll(Lists.newArrayList(Iterables.concat(studentInstitutionTenantAssessmentMap.get(student.getInstitutionIdentifier()).values())));
-        }
-        
+        final List<Assessment> implicitAssessments = eligibilityEvaluatorCache.getImplicitAssessments(
+            student.getInstitutionIdentifier(), student.getStateAbbreviation(), sb11EntityService, assessmentRepository);
         for (final Assessment assess : implicitAssessments) {
             evaluateImplicitRules(assess, student);
         }
@@ -330,7 +345,7 @@ public class EligibilityEvaluatorImpl implements EligibilityEvaluator {
             // filter students
 
             final String tenantId = source.getTenantId();
-            final Tenant tenant = this.progmanClient.getTenantById(tenantId);
+            final Tenant tenant = this.eligibilityEvaluatorCache.getTenantById(tenantId);
             if (tenant == null) {
                 break;
             }
@@ -642,32 +657,5 @@ public class EligibilityEvaluatorImpl implements EligibilityEvaluator {
         }
     }
 
-    private TenantType convertHierarchyLevelToTenantType(final HierarchyLevel level) {
-        TenantType converted = null;
 
-        switch (level) {
-        case DISTRICT:
-            converted = TenantType.DISTRICT;
-            break;
-        case GROUPOFDISTRICTS:
-            converted = TenantType.DISTRICT_GROUP;
-            break;
-        case GROUPOFINSTITUTIONS:
-            converted = TenantType.INSTITUTION_GROUP;
-            break;
-        case GROUPOFSTATES:
-            converted = TenantType.STATE_GROUP;
-            break;
-        case STATE:
-            converted = TenantType.STATE;
-            break;
-        default:
-            converted = null;
-            break;
-        }
-
-        return converted;
-    }
-    
-    
 }

--- a/persistence/src/main/java/org/opentestsystem/delivery/testreg/eligibility/EligibilityEvaluatorImpl.java
+++ b/persistence/src/main/java/org/opentestsystem/delivery/testreg/eligibility/EligibilityEvaluatorImpl.java
@@ -59,90 +59,92 @@ import java.util.Set;
 
 
 @Component
-public class EligibilityEvaluatorImpl implements EligibilityEvaluator {
+class EligibilityEvaluatorCache {
 
-    @Component
-    static class EligibilityEvaluatorCache {
+    private final ProgManClient progmanClient;
+    private final TenancyService tenancyService;
+    private final AssessmentRepository assessmentRepository;
+    private final Sb11EntityRepositoryService sb11EntityService;
 
-        @Autowired
-        private ProgManClient progmanClient;
-
-        @Autowired
-        private TenancyService tenancyService;
-
-        @Cacheable("tenantById")
-        public Tenant getTenantById(String tenantId) {
-            return this.progmanClient.getTenantById(tenantId);
-        }
-
-        @Cacheable("applicableTenants")
-        public List<String> getApplicableTenantIds(final Set<SbacEntity> possibleTenants) {
-            List<Tenant> tenantsForAssessment = Lists.newArrayList();
-            if (!CollectionUtils.isEmpty(possibleTenants)) {
-                tenantsForAssessment = tenancyService.getApplicableTenants(possibleTenants);
-            }
-            final List<String> tenantIdsForAssessment = Lists.newArrayList();
-            if (!CollectionUtils.isEmpty(tenantsForAssessment)) {
-                tenantIdsForAssessment.addAll(Lists.transform(tenantsForAssessment, ARTHelpers.TENANT_ID_TRANSFORMER));
-            }
-            return tenantIdsForAssessment;
-        }
-
-        @Cacheable("implicitAssessments")
-        public List<Assessment> getImplicitAssessments(String institutionIdentifier, String stateAbbreviation, Sb11EntityRepositoryService sb11EntityService, AssessmentRepository assessmentRepository) {
-            // go up the hierarchy to find all the entities up to the client and add to the hash set
-            // we need to know if any of the levels are tenants so we grab all possible assessments for the hierarchy
-            Sb11Entity entity = sb11EntityService.findByEntityIdAndStateAbbreviation(institutionIdentifier, stateAbbreviation, InstitutionEntity.class);
-
-            // create the initial set with the institution level
-            final Set<SbacEntity> possibleTenants = Sets.newHashSet(new SbacEntity(TenantType.INSTITUTION, institutionIdentifier, "nothing"));
-
-            while (entity != null) {
-                if (entity.getParentEntityType() != null) {
-                    final TenantType tenantType = convertHierarchyLevelToTenantType(entity.getParentEntityType());
-                    if (tenantType != null) {
-                        possibleTenants.add(new SbacEntity(tenantType, entity.getParentEntityId(), "nothing"));
-                    }
-                }
-                entity = entity.getParentEntityId() != null ? sb11EntityService.getParentEntity(entity) : null;
-            }
-
-            // find all assessments for possible tenants
-            final List<String> tenantIdsForAssessment = getApplicableTenantIds(possibleTenants);
-            List<Assessment> implicitAssessments = Lists.newArrayList();
-            if (!CollectionUtils.isEmpty(tenantIdsForAssessment)) {
-                implicitAssessments = assessmentRepository.findByEligibilityTypeAndTenantIdIsIn("IMPLICIT", tenantIdsForAssessment);
-            }
-            return CollectionUtils.isEmpty(implicitAssessments) ? new ArrayList<Assessment>() : implicitAssessments;
-        }
-
-        private static TenantType convertHierarchyLevelToTenantType(final HierarchyLevel level) {
-            TenantType converted = null;
-
-            switch (level) {
-                case DISTRICT:
-                    converted = TenantType.DISTRICT;
-                    break;
-                case GROUPOFDISTRICTS:
-                    converted = TenantType.DISTRICT_GROUP;
-                    break;
-                case GROUPOFINSTITUTIONS:
-                    converted = TenantType.INSTITUTION_GROUP;
-                    break;
-                case GROUPOFSTATES:
-                    converted = TenantType.STATE_GROUP;
-                    break;
-                case STATE:
-                    converted = TenantType.STATE;
-                    break;
-                default:
-                    converted = null;
-                    break;
-            }
-
-            return converted;
-        }
+    // Unused but for CGLIB to create proxy objects (for @Cacheable).
+    EligibilityEvaluatorCache() {
+        progmanClient = null; tenancyService = null; assessmentRepository = null; sb11EntityService = null;
     }
+
+    @Autowired
+    EligibilityEvaluatorCache(
+        ProgManClient progmanClient,
+        TenancyService tenancyService,
+        AssessmentRepository assessmentRepository,
+        Sb11EntityRepositoryService sb11EntityService) {
+        this.progmanClient = progmanClient;
+        this.tenancyService = tenancyService;
+        this.assessmentRepository = assessmentRepository;
+        this.sb11EntityService = sb11EntityService;
+    }
+
+    @Cacheable("tenantById")
+    public Tenant getTenantById(String tenantId) {
+        return this.progmanClient.getTenantById(tenantId);
+    }
+
+    @Cacheable("applicableTenants")
+    public List<String> getApplicableTenantIds(final Set<SbacEntity> possibleTenants) {
+        return Lists.transform(tenancyService.getApplicableTenants(possibleTenants), ARTHelpers.TENANT_ID_TRANSFORMER);
+    }
+
+    @Cacheable("implicitAssessments")
+    public List<Assessment> getImplicitAssessments(String institutionIdentifier, String stateAbbreviation) {
+        // create the initial set with the institution level
+        final Set<SbacEntity> possibleTenants = Sets.newHashSet(new SbacEntity(TenantType.INSTITUTION, institutionIdentifier, "nothing"));
+        // go up the hierarchy to find all the entities up to the client and add to the hash set
+        // we need to know if any of the levels are tenants so we grab all possible assessments for the hierarchy
+        Sb11Entity entity = sb11EntityService.findByEntityIdAndStateAbbreviation(institutionIdentifier, stateAbbreviation, InstitutionEntity.class);
+        while (entity != null) {
+            if (entity.getParentEntityType() != null) {
+                final TenantType tenantType = convertHierarchyLevelToTenantType(entity.getParentEntityType());
+                if (tenantType != null) {
+                    possibleTenants.add(new SbacEntity(tenantType, entity.getParentEntityId(), "nothing"));
+                }
+            }
+            entity = entity.getParentEntityId() != null ? sb11EntityService.getParentEntity(entity) : null;
+        }
+        // find all assessments for possible tenants
+        List<Assessment> implicitAssessments = assessmentRepository.findByEligibilityTypeAndTenantIdIsIn(
+            "IMPLICIT", getApplicableTenantIds(possibleTenants));
+        return CollectionUtils.isEmpty(implicitAssessments) ? new ArrayList<Assessment>() : implicitAssessments; // repo can return null
+    }
+
+    private static TenantType convertHierarchyLevelToTenantType(final HierarchyLevel level) {
+        TenantType converted = null;
+
+        switch (level) {
+            case DISTRICT:
+                converted = TenantType.DISTRICT;
+                break;
+            case GROUPOFDISTRICTS:
+                converted = TenantType.DISTRICT_GROUP;
+                break;
+            case GROUPOFINSTITUTIONS:
+                converted = TenantType.INSTITUTION_GROUP;
+                break;
+            case GROUPOFSTATES:
+                converted = TenantType.STATE_GROUP;
+                break;
+            case STATE:
+                converted = TenantType.STATE;
+                break;
+            default:
+                converted = null;
+                break;
+        }
+
+        return converted;
+    }
+}
+
+@Component
+public class EligibilityEvaluatorImpl implements EligibilityEvaluator {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(EligibilityEvaluatorImpl.class);
 
@@ -253,7 +255,7 @@ public class EligibilityEvaluatorImpl implements EligibilityEvaluator {
         this.eligibilityService.removeAllAssociationsForStudent(student);
 
         final List<Assessment> implicitAssessments = eligibilityEvaluatorCache.getImplicitAssessments(
-            student.getInstitutionIdentifier(), student.getStateAbbreviation(), sb11EntityService, assessmentRepository);
+            student.getInstitutionIdentifier(), student.getStateAbbreviation());
         for (final Assessment assess : implicitAssessments) {
             evaluateImplicitRules(assess, student);
         }

--- a/persistence/src/main/java/org/opentestsystem/delivery/testreg/persistence/config/TestRegCachingConfig.java
+++ b/persistence/src/main/java/org/opentestsystem/delivery/testreg/persistence/config/TestRegCachingConfig.java
@@ -39,12 +39,26 @@ public class TestRegCachingConfig {
                 .memoryStoreEvictionPolicy(MemoryStoreEvictionPolicy.LRU));
         config.addCache(c.getCacheConfiguration());
 
-        // Only cache this progman data for one hour.
+        // Set long TTL on progman data.
+        final Cache tc = new Cache(
+            new CacheConfiguration("tenantById", 1000)
+                .timeToLiveSeconds(1 * 60 * 60)
+                .memoryStoreEvictionPolicy(MemoryStoreEvictionPolicy.LRU));
+        config.addCache(tc.getCacheConfiguration());
+
+        // Set long TTL on progman data.
         final Cache atc = new Cache(
-            new CacheConfiguration("applicableTenants", 10000)
+            new CacheConfiguration("applicableTenants", 1000)
                 .timeToLiveSeconds(1 * 60 * 60)
                 .memoryStoreEvictionPolicy(MemoryStoreEvictionPolicy.LRU));
         config.addCache(atc.getCacheConfiguration());
+
+        // Set short TTL on calculated sb11Entity data.
+        final Cache iac = new Cache(
+            new CacheConfiguration("implicitAssessments", 1000)
+                .timeToLiveSeconds(5 * 60)
+                .memoryStoreEvictionPolicy(MemoryStoreEvictionPolicy.LRU));
+        config.addCache(iac.getCacheConfiguration());
 
         return net.sf.ehcache.CacheManager.newInstance(config);
     }


### PR DESCRIPTION
ART import performance: 
Cache repeatedly calculated tenant by institution/state info and clean up ad-hoc cache map.
Added a second progman lookup cache.