### PR TITLE
Remove last page button if search results are truncated.

### DIFF
--- a/webapp/src/main/webapp/resources/testreg/partials/pageable-table.html
+++ b/webapp/src/main/webapp/resources/testreg/partials/pageable-table.html
@@ -15,7 +15,7 @@
 			 	<li data-ng-show="pagingInfo.prevPageUrl" data-ng-click="prevPage()"><span class="tbNav tbprev"></span> Previous</li>
 			 	<li>Page: <input type="text" data-ng-change="changePage()" data-ng-model="searchParams.currentPage"/></li>
 			 	<li data-ng-show="pagingInfo.nextPageUrl" data-ng-click="nextPage()">Next <span class="tbNav tbnext"></span></li>
-				<li data-ng-show="pagingInfo.nextPageUrl" data-ng-click="lastPage()">Last <span class="tbNav tblast"></span></li>
+				<li data-ng-show="pagingInfo.nextPageUrl && pagingInfo.totalCount <= 1000" data-ng-click="lastPage()">Last <span class="tbNav tblast"></span></li>
 			</ul>
 		</th>
 		</tr>


### PR DESCRIPTION
Remove last page button when results are truncated, as it's extremely slow and also inaccurate (it doesn't go to the last page of all the records).