### PR TITLE
add knownHosts property

### DIFF
--- a/persistence/src/main/resources/spring/service-context.xml
+++ b/persistence/src/main/resources/spring/service-context.xml
@@ -103,6 +103,7 @@
         <!--<property name="port" value="${testreg.sftp.port}" />-->
         <property name="user" value="${testreg.sftp.user}" />
         <property name="password" value="${testreg.sftp.pass}" />
+        <property name="knownHosts" value="${testreg.sftp.knownHosts}"/>
     </bean>
     
     <bean id="sb11TimeZoneBuilder" class="org.opentestsystem.delivery.Sb11TimeZoneBuilder"/>


### PR DESCRIPTION
If spring sftp integration is set to not allow unknown hosts, a pre-populated knownHosts file is required.

The knownHosts property specifies the filename that will be used for a host key repository. The file has the same format as OpenSSH’s known_hosts file.

The behavior was changed in spring-integration 4.2.  This version of ART is using spring-integration 4.3.11.RELEASE

see: https://docs.spring.io/spring-integration/reference/html/sftp.html#sftp-session-factory-properties