### PR TITLE
disable cache for static resources

### DIFF
--- a/rest/src/main/resources/spring/servlet-context.xml
+++ b/rest/src/main/resources/spring/servlet-context.xml
@@ -11,7 +11,7 @@
     <!-- swagger resources -->
     <resources mapping="swagger-ui.html" location="classpath:/META-INF/resources/" />
     <resources mapping="/webjars/**" location="classpath:/META-INF/resources/webjars/" />
-    <resources mapping="/resources/**" location="/resources/" />
+    <resources mapping="/resources/**" location="/resources/" cache-period="0" />
   
     <beans:bean class="org.springframework.web.servlet.view.InternalResourceViewResolver">
     	<beans:property  name="order" value="2" />


### PR DESCRIPTION
Fix for issue when a user logs out and logs back in.
After the user enters credentials, an error message is displayed:
There was an issue logging in, please ensure you have the proper role and tenancy for this application.