### PR TITLE
Skip UserChangeEvent processing for users with missing sb11 entity.

### DIFF
--- a/client-interfaces/pom.xml
+++ b/client-interfaces/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opentestsystem.delivery</groupId>
     <artifactId>test-reg-parent</artifactId>
-    <version>3.1.4.RELEASE</version>
+    <version>3.1.5.RELEASE</version>
   </parent>
   <artifactId>test-reg-client-interfaces</artifactId>
   

--- a/client/pom.xml
+++ b/client/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opentestsystem.delivery</groupId>
     <artifactId>test-reg-parent</artifactId>
-    <version>3.1.4.RELEASE</version>
+    <version>3.1.5.RELEASE</version>
   </parent>
   <artifactId>test-reg-client</artifactId>
   

--- a/domain/pom.xml
+++ b/domain/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.opentestsystem.delivery</groupId>
     <artifactId>test-reg-parent</artifactId>
-    <version>3.1.4.RELEASE</version>
+    <version>3.1.5.RELEASE</version>
   </parent>
   
   <artifactId>test-reg-domain</artifactId>

--- a/null-client/pom.xml
+++ b/null-client/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opentestsystem.delivery</groupId>
     <artifactId>test-reg-parent</artifactId>
-    <version>3.1.4.RELEASE</version>
+    <version>3.1.5.RELEASE</version>
   </parent>
   <artifactId>test-reg-null-client</artifactId>
   

--- a/persistence/pom.xml
+++ b/persistence/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opentestsystem.delivery</groupId>
     <artifactId>test-reg-parent</artifactId>
-    <version>3.1.4.RELEASE</version>
+    <version>3.1.5.RELEASE</version>
   </parent>
   <artifactId>test-reg-persistence</artifactId>
   

--- a/persistence/src/main/java/org/opentestsystem/delivery/testreg/service/impl/UserChangeEventExportServiceImpl.java
+++ b/persistence/src/main/java/org/opentestsystem/delivery/testreg/service/impl/UserChangeEventExportServiceImpl.java
@@ -97,7 +97,8 @@ public class UserChangeEventExportServiceImpl implements UserChangeEventExportSe
                         userChangeEventsAsXML.append(convertToXML(userChangeEvent)).append("\n");
                         userChangeEventsAddedToXML++;
                     } catch (CannotExportUserChangeEventException ex) {
-                        LOGGER.warn("we are skipping a user change event for user (" + userChangeEvent.getModifiedUserId()
+                        LOGGER.warn("Skipping user change event for user (" + userChangeEvent.getModifiedUserId()
+                                + "): Action: (" + userChangeEvent.getAction()
                                 + "): " + ex.getMessage());
                     }
                 }
@@ -290,7 +291,7 @@ public class UserChangeEventExportServiceImpl implements UserChangeEventExportSe
                         roleHierarchyInfo.add(Arrays.asList(FormatType.valueOf(hierarchyLevel.name()).getFormatName(),
                                 sb11Entity.getEntityId(), sb11Entity.getEntityName()));
                     } else {
-                        throw new RuntimeException("missing sb11 entity [id: " + currentEntityMongoId + ", type: "
+                        throw new CannotExportUserChangeEventException("missing sb11 entity [id: " + currentEntityMongoId + ", type: "
                                 + FormatType.valueOf(currentHierarchyLevel.name()) + "]");
                     }
                 } else {

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.opentestsystem.delivery</groupId>
     <artifactId>test-reg-parent</artifactId>
-    <version>3.1.4.RELEASE</version>
+    <version>3.1.5.RELEASE</version>
     <name>Smarter Balanced #11 Test Registration - Parent Project</name>
     <packaging>pom</packaging>
 
@@ -47,7 +47,7 @@
         <connection>scm:git:https://github.com/SmarterApp/TDS_AdministrationAndRegistrationTools.git</connection>
         <developerConnection>scm:git:git://github.com/SmarterApp/TDS_AdministrationAndRegistrationTools.git</developerConnection>
         <url>https://github.com/SmarterApp/TDS_AdministrationAndRegistrationTools</url>
-        <tag>3.1.4.RELEASE</tag>
+        <tag>3.1.5.RELEASE</tag>
     </scm>
 
     <dependencies>

--- a/rest/pom.xml
+++ b/rest/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opentestsystem.delivery</groupId>
     <artifactId>test-reg-parent</artifactId>
-    <version>3.1.4.RELEASE</version>
+    <version>3.1.5.RELEASE</version>
   </parent>
   <artifactId>testreg.rest</artifactId>
   <packaging>war</packaging>

--- a/webapp/pom.xml
+++ b/webapp/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opentestsystem.delivery</groupId>
     <artifactId>test-reg-parent</artifactId>
-    <version>3.1.4.RELEASE</version>
+    <version>3.1.5.RELEASE</version>
   </parent>
   <artifactId>testreg.webapp</artifactId>
   <packaging>war</packaging>


### PR DESCRIPTION
Skip UserChangeEvent processing for users with missing sb11 entity.

This fixes a bug where this particular problem with a user would
cause further UserChangeEvent's in the queue to never get processed.

UserChangeEventExportServiceImpl.java: Instead of Runtime Exception,
throw a CannotExportUserChangeEventException and use the existing catch
block in exportUserChangeEvents() to skip the UserChangeEvent with
missing sb11 entity.