### PR TITLE
Skip UserChangeEvent processing for users with missing sb11 entity.

### DIFF
--- a/persistence/src/main/java/org/opentestsystem/delivery/testreg/service/impl/UserChangeEventExportServiceImpl.java
+++ b/persistence/src/main/java/org/opentestsystem/delivery/testreg/service/impl/UserChangeEventExportServiceImpl.java
@@ -97,7 +97,8 @@ public class UserChangeEventExportServiceImpl implements UserChangeEventExportSe
                         userChangeEventsAsXML.append(convertToXML(userChangeEvent)).append("\n");
                         userChangeEventsAddedToXML++;
                     } catch (CannotExportUserChangeEventException ex) {
-                        LOGGER.warn("we are skipping a user change event for user (" + userChangeEvent.getModifiedUserId()
+                        LOGGER.warn("Skipping user change event for user (" + userChangeEvent.getModifiedUserId()
+                                + "): Action: (" + userChangeEvent.getAction()
                                 + "): " + ex.getMessage());
                     }
                 }
@@ -290,7 +291,7 @@ public class UserChangeEventExportServiceImpl implements UserChangeEventExportSe
                         roleHierarchyInfo.add(Arrays.asList(FormatType.valueOf(hierarchyLevel.name()).getFormatName(),
                                 sb11Entity.getEntityId(), sb11Entity.getEntityName()));
                     } else {
-                        throw new RuntimeException("missing sb11 entity [id: " + currentEntityMongoId + ", type: "
+                        throw new CannotExportUserChangeEventException("missing sb11 entity [id: " + currentEntityMongoId + ", type: "
                                 + FormatType.valueOf(currentHierarchyLevel.name()) + "]");
                     }
                 } else {


### PR DESCRIPTION
Skip UserChangeEvent processing for users with missing sb11 entity.

This fixes a bug where this particular problem with a user would
cause further UserChangeEvent's in the queue to never get processed. (https://sbacjira.atlassian.net/browse/ART-14)

UserChangeEventExportServiceImpl.java: Instead of Runtime Exception,
throw a CannotExportUserChangeEventException and use the existing catch
block in exportUserChangeEvents() to skip the UserChangeEvent with
missing sb11 entity.