### PR TITLE
Update support tool client version.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
         <sb11-shared-security.version>4.0.4</sb11-shared-security.version>
         <tds-dll.version>4.0.4</tds-dll.version>
         <tsb-client.version>4.0.2</tsb-client.version>
-        <support-tool-client.version>0.0.8</support-tool-client.version>
+        <support-tool-client.version>0.0.14</support-tool-client.version>
     </properties>
 
     <build>


### PR DESCRIPTION
Support tool client versions 0.0.9 to 0.0.13 have incompatible tds-common dependency. In 0.0.14 that has been moved to support tool service instead, and removed from here.