### PR TITLE
Widen AOP pointcut specifiers to fix missing repository events.

### DIFF
--- a/persistence/src/main/java/org/opentestsystem/delivery/testreg/aop/EligibilityEventAspect.java
+++ b/persistence/src/main/java/org/opentestsystem/delivery/testreg/aop/EligibilityEventAspect.java
@@ -34,14 +34,14 @@ public class EligibilityEventAspect {
     @Autowired
     private EventCreatorFactory eventCreatorFactory;
 
-    @Pointcut("execution(* org.opentestsystem.delivery.testreg.persistence.UserChangeEventRepository.*(..))")
+    @Pointcut("execution(* org.opentestsystem.delivery.testreg.persistence.UserChangeEventRepository+.*(..))")
     public void inUserChangeRepository() {
         // just used to define common pointcut
     }
 
     // Pointcut for <S extends T> S save(S entity) & <S extends T> Iterable<S> save(Iterable<S> entities); specifically for implementations of TestRegistrationBase
     @SuppressWarnings("unchecked")
-    @AfterReturning(pointcut = "!inUserChangeRepository() && execution(* org.opentestsystem.delivery.testreg.persistence.*Repository.save(..))", returning = "result")
+    @AfterReturning(pointcut = "!inUserChangeRepository() && execution(* org.opentestsystem.delivery.testreg.persistence.*Repository+.save(..))", returning = "result")
     public void save(final Object result) {
         if (result != null && result instanceof TestRegistrationBase) {
             if (LOGGER.isDebugEnabled()) {
@@ -71,13 +71,13 @@ public class EligibilityEventAspect {
     }
 
     // Pointcut for void delete(T entity);
-    @AfterReturning(pointcut = "!inUserChangeRepository() && execution(* org.opentestsystem.delivery.testreg.persistence.*Repository.delete(..)) && args(domainIn)")
+    @AfterReturning(pointcut = "!inUserChangeRepository() && execution(* org.opentestsystem.delivery.testreg.persistence.*Repository+.delete(..)) && args(domainIn)")
     public void delete(final TestRegistrationBase domainIn) {
         saveChangeEvent(domainIn, true);
     }
 
     // Pointcut for void delete(Iterable<? extends T> entities);
-    @AfterReturning(pointcut = "!inUserChangeRepository() && execution(* org.opentestsystem.delivery.testreg.persistence.*Repository.delete(..)) && args(domainsIn)")
+    @AfterReturning(pointcut = "!inUserChangeRepository() && execution(* org.opentestsystem.delivery.testreg.persistence.*Repository+.delete(..)) && args(domainsIn)")
     public void delete(final List<TestRegistrationBase> domainsIn) {
         for (final TestRegistrationBase domainIn : domainsIn) {
             saveChangeEvent(domainIn, true);

--- a/persistence/src/main/java/org/opentestsystem/delivery/testreg/aop/SecuredAnnotationAspect.java
+++ b/persistence/src/main/java/org/opentestsystem/delivery/testreg/aop/SecuredAnnotationAspect.java
@@ -13,11 +13,9 @@ import static org.springframework.web.bind.annotation.RequestMethod.GET;
 import static org.springframework.web.bind.annotation.RequestMethod.PATCH;
 import static org.springframework.web.bind.annotation.RequestMethod.POST;
 import static org.springframework.web.bind.annotation.RequestMethod.PUT;
-
 import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.List;
-
 import org.aspectj.lang.ProceedingJoinPoint;
 import org.aspectj.lang.annotation.AfterReturning;
 import org.aspectj.lang.annotation.Around;
@@ -42,6 +40,10 @@ import org.springframework.stereotype.Component;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 
+
+
+
+
 @Component
 @Aspect
 public class SecuredAnnotationAspect {
@@ -60,7 +62,7 @@ public class SecuredAnnotationAspect {
     private boolean triggerSet;
 
     @SuppressWarnings("unchecked")
-    @Around("execution(* org.opentestsystem.shared.search.persistence.SearchableRepository.search(..)) && args(searchRequest)")
+    @Around("execution(* org.opentestsystem.shared.search.persistence.SearchableRepository+.search(..)) && args(searchRequest)")
     public <T extends TestRegistrationBase> SearchResponse<T> interceptSearchDomainObjects(ProceedingJoinPoint pjp,
             AbstractTestRegSearchRequest searchRequest) throws Throwable {
 
@@ -82,22 +84,22 @@ public class SecuredAnnotationAspect {
         return (SearchResponse<T>) pjp.proceed();
     }
 
-    @AfterReturning(pointcut = "execution(* org.opentestsystem.delivery.testreg.persistence.Sb11EntityRepository.save*(..))  && args(sb11EntityIn)", returning = "sb11EntityOut")
+    @AfterReturning(pointcut = "execution(* org.opentestsystem.delivery.testreg.persistence.Sb11EntityRepository+.save*(..))  && args(sb11EntityIn)", returning = "sb11EntityOut")
     public void handleEntityChanges(Sb11Entity sb11EntityIn, Sb11Entity sb11EntityOut) throws Throwable {
         testRegUberEntityRelationshipService.updateUberEntityRelationshipMap(sb11EntityOut);
     }
 
-    @AfterReturning(pointcut = "execution(* org.opentestsystem.delivery.testreg.persistence.Sb11EntityRepository.delete*(..)) && args(sb11EntityIn)")
+    @AfterReturning(pointcut = "execution(* org.opentestsystem.delivery.testreg.persistence.Sb11EntityRepository+.delete*(..)) && args(sb11EntityIn)")
     public void handleEntityChanges(Sb11Entity sb11EntityIn) throws Throwable {
         testRegUberEntityRelationshipService.updateUberEntityRelationshipMapDeletion(sb11EntityIn);
     }
 
-    @AfterReturning(pointcut = "execution(* org.opentestsystem.delivery.testreg.persistence.Sb11EntityRepository.delete*(..)) && args(pkId)")
+    @AfterReturning(pointcut = "execution(* org.opentestsystem.delivery.testreg.persistence.Sb11EntityRepository+.delete*(..)) && args(pkId)")
     public void handleEntityChanges(String pkId) throws Throwable {
         testRegUberEntityRelationshipService.updateUberEntityRelationshipMapDeletion(pkId);
     }
 
-    @AfterReturning("execution(* org.opentestsystem.delivery.testreg.persistence.Sb11EntityRepository.save*(..)) || execution(* org.opentestsystem.delivery.testreg.persistence.Sb11EntityRepository.delete*(..))")
+    @AfterReturning("execution(* org.opentestsystem.delivery.testreg.persistence.Sb11EntityRepository+.save*(..)) || execution(* org.opentestsystem.delivery.testreg.persistence.Sb11EntityRepository.delete*(..))")
     public void handleEntityChanges() throws Throwable {
         LOGGER.debug("intercepted a change that may affect the cached entity tree, evicting and rebuilding uber entity relationship map...");
         if (!triggerSet || (triggerSet && trigger.isTriggerFired())) {

--- a/persistence/src/main/java/org/opentestsystem/delivery/testreg/aop/UserChangeEventAspect.java
+++ b/persistence/src/main/java/org/opentestsystem/delivery/testreg/aop/UserChangeEventAspect.java
@@ -11,7 +11,6 @@ package org.opentestsystem.delivery.testreg.aop;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-
 import org.aspectj.lang.ProceedingJoinPoint;
 import org.aspectj.lang.annotation.AfterReturning;
 import org.aspectj.lang.annotation.Around;
@@ -25,6 +24,8 @@ import org.opentestsystem.delivery.testreg.service.UserChangeEventService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
+
+
 @Component
 @Aspect
 public class UserChangeEventAspect {
@@ -36,7 +37,7 @@ public class UserChangeEventAspect {
     private TestRegPersister userService;
 
     // Pointcut for <S extends T> S save(S entity);
-    @Around("execution(* org.opentestsystem.delivery.testreg.persistence.UserRepository.save(..)) && args(userIn)")
+    @Around("execution(* org.opentestsystem.delivery.testreg.persistence.UserRepository+.save(..)) && args(userIn)")
     public User save(final ProceedingJoinPoint pjp, final User userIn) throws Throwable {
         SSOAction action = userIn.getId() == null ? SSOAction.ADD : SSOAction.MOD;
         User userOut = (User) pjp.proceed();
@@ -54,7 +55,7 @@ public class UserChangeEventAspect {
     }
 
     // Pointcut for <S extends T> Iterable<S> save(Iterable<S> entities);
-    @Around("execution(* org.opentestsystem.delivery.testreg.persistence.UserRepository.save(..)) && args(usersIn)")
+    @Around("execution(* org.opentestsystem.delivery.testreg.persistence.UserRepository+.save(..)) && args(usersIn)")
     public Iterable<User> save(final ProceedingJoinPoint pjp, final Iterable<User> usersIn) throws Throwable {
 
         // loop thru and create MOD change events for existing users
@@ -86,19 +87,19 @@ public class UserChangeEventAspect {
     }
 
     // Pointcut for void delete(T entity);
-    @AfterReturning(pointcut = "execution(* org.opentestsystem.delivery.testreg.persistence.UserRepository.delete(..)) && args(userIn)")
+    @AfterReturning(pointcut = "execution(* org.opentestsystem.delivery.testreg.persistence.UserRepository+.delete(..)) && args(userIn)")
     public void delete(final User userIn) {
         saveUserChangeEvent(new UserChangeEvent(userIn.getId(), SSOAction.DEL));
     }
 
     // Pointcut for void delete(ID id);
-    @AfterReturning("execution(* org.opentestsystem.delivery.testreg.persistence.UserRepository.delete(..)) && args(id)")
+    @AfterReturning("execution(* org.opentestsystem.delivery.testreg.persistence.UserRepository+.delete(..)) && args(id)")
     public void delete(final String id) {
         saveUserChangeEvent(new UserChangeEvent(id, SSOAction.DEL));
     }
 
     // Pointcut for void delete(Iterable<? extends T> entities);
-    @AfterReturning(pointcut = "execution(* org.opentestsystem.delivery.testreg.persistence.UserRepository.delete(..)) && args(usersIn)")
+    @AfterReturning(pointcut = "execution(* org.opentestsystem.delivery.testreg.persistence.UserRepository+.delete(..)) && args(usersIn)")
     public void delete(final Iterable<User> usersIn) {
         for (User userIn : usersIn) {
             saveUserChangeEvent(new UserChangeEvent(userIn.getId(), SSOAction.DEL));
@@ -106,7 +107,7 @@ public class UserChangeEventAspect {
     }
 
     // Pointcut for void deleteAll();
-    @Around("execution(* org.opentestsystem.delivery.testreg.persistence.UserRepository.deleteAll())")
+    @Around("execution(* org.opentestsystem.delivery.testreg.persistence.UserRepository+.deleteAll())")
     public void deleteAll(final ProceedingJoinPoint pjp) throws Throwable {
         List<User> users = userService.findAll(FormatType.USER);
         pjp.proceed();


### PR DESCRIPTION
UserChangeEvents are now being created again on UserRepository save events.

This bug cropped up due to our recent spring upgrade - AOP pointcut specification matching has been made more strict. The + flag is now required to match implementations of the named interface, which is what the Repository classes are that are generally hooked. The newer spring wouldn't hook/call these pointcut AOP methods without the +.