### PR TITLE
Bugfix/user upload

### DIFF
--- a/domain/src/main/java/org/opentestsystem/delivery/testreg/domain/User.java
+++ b/domain/src/main/java/org/opentestsystem/delivery/testreg/domain/User.java
@@ -17,6 +17,7 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 import javax.validation.Valid;
 import javax.validation.constraints.Pattern;
@@ -481,11 +482,11 @@ public class User implements Sb11NonEntity {
      * @return True if this user is the same as the user that was compared against; otherwise false.
      */
     public boolean isSameAs(final User other) {
-        return  getId().equals(other.getId())
-                && getFirstName().equals(other.getFirstName())
-                && getLastName().equals(other.getLastName())
-                && getEmail().equals(other.getEmail())
-                && getPhone().equals(other.getPhone())
-                && getRoleAssociations().equals(other.getRoleAssociations());
+        return Objects.equals(getId(), other.getId())
+                && Objects.equals(getFirstName(), other.getFirstName())
+                && Objects.equals(getLastName(), other.getLastName())
+                && Objects.equals(getEmail(), other.getEmail())
+                && Objects.equals(getPhone(), other.getPhone())
+                && Objects.equals(getRoleAssociations(), other.getRoleAssociations());
     }
 }

--- a/domain/src/main/java/org/opentestsystem/delivery/testreg/domain/User.java
+++ b/domain/src/main/java/org/opentestsystem/delivery/testreg/domain/User.java
@@ -107,7 +107,7 @@ public class User implements Sb11NonEntity {
     private String delete;
 
     private String changeEventExportError = null;
-    
+
     // flag to determine if user being edited or viewed has roles outside logged-in-user jurisdiction or not 
     @Transient
     private Boolean hasRolesOutside;
@@ -130,7 +130,7 @@ public class User implements Sb11NonEntity {
         @FieldLabel("AssociatedEntityID")
         @XStreamAlias("RoleID")
         private String associatedEntityId;
-        
+
         @Transient
         @XStreamOmitField
         private String associatedEntityName;
@@ -210,7 +210,7 @@ public class User implements Sb11NonEntity {
         public void setAssociatedEntityId(final String inAssociatedEntityId) {
             this.associatedEntityId = inAssociatedEntityId;
         }
-        
+
         public String getAssociatedEntityName() {
           return associatedEntityName;
         }
@@ -396,15 +396,15 @@ public class User implements Sb11NonEntity {
     }
 
     /**
-     * @return true if the edit/view user has roles outside logged-in-user jurisdiction, otherwise false 
+     * @return true if the edit/view user has roles outside logged-in-user jurisdiction, otherwise false
      */
     public Boolean getHasRolesOutside () {
       return hasRolesOutside;
     }
-    
+
     /**
-     * 
-     * @param hasRolesOutside hasRolesOutside to set ( true/false ) 
+     *
+     * @param hasRolesOutside hasRolesOutside to set ( true/false )
      *        true indicates edit/view user has roles outside logged-in-user jurisdiction,
      *        Otherwise false
      */
@@ -461,5 +461,31 @@ public class User implements Sb11NonEntity {
         reqMap.put(UserSearchRequest.SEARCH_KEY_EMAIL_INSENSITIVE, new String[] { email });
         UserSearchRequest request = new UserSearchRequest(reqMap);
         return request;
+    }
+
+    /**
+     * Determine if this {@link org.opentestsystem.delivery.testreg.domain.User} is the same as another
+     * {@link org.opentestsystem.delivery.testreg.domain.User}.
+     * <p>
+     *     This method is used by the bulk upload process to determine if a
+     *     {@link org.opentestsystem.delivery.testreg.domain.UserChangeEvent} needs to be created to notify the
+     *     downstream user management system (i.e. OpenDJ) of any changes to the user's account.
+     * </p>
+     * <p>
+     *     The reason this method exists is because {@link org.opentestsystem.delivery.testreg.domain.User#equals(Object)}
+     *     is already overridden in this class.  Rather than potentially breaking the program by  changing how the
+     *     {@link #equals(Object)} method works, this method has been introduced to determine if/when a
+     *     {@link org.opentestsystem.delivery.testreg.domain.User} needs to be updated.
+     * </p>
+     * @param other The {@link org.opentestsystem.delivery.testreg.domain.User} to compare this user to
+     * @return True if this user is the same as the user that was compared against; otherwise false.
+     */
+    public boolean isSameAs(final User other) {
+        return  getId().equals(other.getId())
+                && getFirstName().equals(other.getFirstName())
+                && getLastName().equals(other.getLastName())
+                && getEmail().equals(other.getEmail())
+                && getPhone().equals(other.getPhone())
+                && getRoleAssociations().equals(other.getRoleAssociations());
     }
 }

--- a/persistence/src/main/java/org/opentestsystem/delivery/testreg/aop/UserChangeEventAspect.java
+++ b/persistence/src/main/java/org/opentestsystem/delivery/testreg/aop/UserChangeEventAspect.java
@@ -46,17 +46,14 @@ public class UserChangeEventAspect {
         SSOAction action = SSOAction.ADD;
 
         if (userIn.getId() != null) {
-            final User existingUser = userRepository.findOne(userIn.getId());
-            if (existingUser == null) {
-                throw new IllegalStateException(String.format("Could not find a user account for id %s (email: %s)",
-                        userIn.getId(),
-                        userIn.getEmail()));
-            }
-
             // If the user account looks the same in the database as it does after it's been modified, exit (because
-            // there's no change required).
-            if (existingUser.isSameAs(userIn)) {
-                return userIn;
+            // there's no change required).  Otherwise the user account has been modified, so change the action to
+            // indicate as such.
+            final User existingUser = userRepository.findOne(userIn.getId());
+            if (existingUser != null) {
+                if (existingUser.isSameAs(userIn)) {
+                    return userIn;
+                }
             }
 
             action = SSOAction.MOD;

--- a/persistence/src/main/java/org/opentestsystem/delivery/testreg/aop/UserChangeEventAspect.java
+++ b/persistence/src/main/java/org/opentestsystem/delivery/testreg/aop/UserChangeEventAspect.java
@@ -15,10 +15,12 @@ import org.aspectj.lang.ProceedingJoinPoint;
 import org.aspectj.lang.annotation.AfterReturning;
 import org.aspectj.lang.annotation.Around;
 import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.annotation.Before;
 import org.opentestsystem.delivery.testreg.domain.FormatType;
 import org.opentestsystem.delivery.testreg.domain.SSOAction;
 import org.opentestsystem.delivery.testreg.domain.User;
 import org.opentestsystem.delivery.testreg.domain.UserChangeEvent;
+import org.opentestsystem.delivery.testreg.persistence.UserRepository;
 import org.opentestsystem.delivery.testreg.service.TestRegPersister;
 import org.opentestsystem.delivery.testreg.service.UserChangeEventService;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -34,22 +36,33 @@ public class UserChangeEventAspect {
     private UserChangeEventService userChangeEventService;
 
     @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
     private TestRegPersister userService;
 
     // Pointcut for <S extends T> S save(S entity);
     @Around("execution(* org.opentestsystem.delivery.testreg.persistence.UserRepository+.save(..)) && args(userIn)")
     public User save(final ProceedingJoinPoint pjp, final User userIn) throws Throwable {
-        SSOAction action = userIn.getId() == null ? SSOAction.ADD : SSOAction.MOD;
-        User userOut = (User) pjp.proceed();
-        boolean found = false;
-        UserChangeEvent userChangeEvent = new UserChangeEvent(userOut.getId(), action);
-        if (userChangeEvent.getModifiedUserId().equals(userOut.getId())) {
-            found = true;
+        SSOAction action = SSOAction.ADD;
+
+        if (userIn.getId() != null) {
+            final User existingUser = userRepository.findOne(userIn.getId());
+            if (existingUser == null) {
+                throw new IllegalStateException(String.format("Could not find a user account for id %s (email: %s)",
+                        userIn.getId(),
+                        userIn.getEmail()));
+            }
+
+            if (existingUser.isSameAs(userIn)) {
+                return userIn;
+            }
+
+            action = SSOAction.MOD;
         }
-        //only attempt to save a user change event if there isn't one already
-        if (!found) {
-            saveUserChangeEvent(userChangeEvent);
-        }
+
+        final User userOut = (User) pjp.proceed();
+        saveUserChangeEvent(new UserChangeEvent(userIn.getId(), action));
 
         return userOut;
     }

--- a/persistence/src/main/java/org/opentestsystem/delivery/testreg/aop/UserChangeEventAspect.java
+++ b/persistence/src/main/java/org/opentestsystem/delivery/testreg/aop/UserChangeEventAspect.java
@@ -15,7 +15,6 @@ import org.aspectj.lang.ProceedingJoinPoint;
 import org.aspectj.lang.annotation.AfterReturning;
 import org.aspectj.lang.annotation.Around;
 import org.aspectj.lang.annotation.Aspect;
-import org.aspectj.lang.annotation.Before;
 import org.opentestsystem.delivery.testreg.domain.FormatType;
 import org.opentestsystem.delivery.testreg.domain.SSOAction;
 import org.opentestsystem.delivery.testreg.domain.User;

--- a/persistence/src/main/java/org/opentestsystem/delivery/testreg/aop/UserChangeEventAspect.java
+++ b/persistence/src/main/java/org/opentestsystem/delivery/testreg/aop/UserChangeEventAspect.java
@@ -50,10 +50,8 @@ public class UserChangeEventAspect {
             // there's no change required).  Otherwise the user account has been modified, so change the action to
             // indicate as such.
             final User existingUser = userRepository.findOne(userIn.getId());
-            if (existingUser != null) {
-                if (existingUser.isSameAs(userIn)) {
-                    return userIn;
-                }
+            if (existingUser != null && existingUser.isSameAs(userIn)) {
+                return userIn;
             }
 
             action = SSOAction.MOD;

--- a/persistence/src/main/java/org/opentestsystem/delivery/testreg/aop/UserChangeEventAspect.java
+++ b/persistence/src/main/java/org/opentestsystem/delivery/testreg/aop/UserChangeEventAspect.java
@@ -54,6 +54,8 @@ public class UserChangeEventAspect {
                         userIn.getEmail()));
             }
 
+            // If the user account looks the same in the database as it does after it's been modified, exit (because
+            // there's no change required).
             if (existingUser.isSameAs(userIn)) {
                 return userIn;
             }


### PR DESCRIPTION
### Issue
When uploading a CSV file to modify users, there are some cases where the intent is to remove a role from an existing user without deleting the entire user's account.  The role removal is not occurring when using the bulk upload feature for users.

### Analysis
* The `save` aspect had a bug that prevented it from detecting if a role was removed from an existing user
  * Specifically, the `save` aspect would see that the modified user's id was the same as the existing user's id.  If they were the same, it would exit
* The `User#equals` method only compares the user's email address to determine equality, which was not enough to identify what changes had been made to the user account

### Solution
* Add an `User#isSameAs` method to determine if a user account requires an update (i.e. a `UserChangeEvent`)
* Update the `save` aspect to identify the differences between the passed-in user vs the user account stored in the database using the `isSameAs` method
